### PR TITLE
Acf compatibility

### DIFF
--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -1243,11 +1243,24 @@ component output="false" accessors="true" {
   ){
     var sParams = arguments.params;
     for( var key in sParams ){
-      if( !len( sParams[ key ] ) ){
+      if( !hasValue( sParams[ key ] ) ){
         structDelete( sParams, key );
       }
     }
     return sParams;
+  }
+
+  /**
+  * Helper to ensure variables aren't empty
+  */
+  private boolean function hasValue( any value ) {
+    if ( isNull( value ) ) return false;
+    if ( isSimpleValue( value ) ) return len( value );
+    if ( isStruct( value ) ) return !structIsEmpty( value );
+    if ( isArray( value ) ) return arrayLen( value );
+    if ( isQuery( value ) ) return value.recordcount;
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
When complex data types were passed into the structcleanser(), they resulted in an error on ACF. This would happen, for example, when passing the `TemplateModel` struct argument into the `sendEmailWithTemplate()` method. I moved the value evaluation to a separate helper function, which accounts for value by data type.