### PR TITLE
ACF 2016 Compatibility

### DIFF
--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -1243,7 +1243,7 @@ component output="false" accessors="true" {
   ){
     var sParams = arguments.params;
     for( var key in sParams ){
-      if( !hasValue( sParams[ key ] ) ){
+      if( structKeyExists( sParams, key ) && !hasValue( sParams[ key ] ) ){
         structDelete( sParams, key );
       }
     }


### PR DESCRIPTION
Account for different handling of struct values in ACF 2016. Errors were being thrown when a key wasn't present. This was a behavior change from previous versions of ACF.