### PR TITLE
Send the attachment with a custom name to prevent users from receivin…

### DIFF
--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -59,9 +59,9 @@ component output="false" accessors="true" {
         arrayAppend(
           aAttachments,
           {
-            'Name'        = attachment,
-            'Content'     = toBase64( fileReadBinary( attachment ) ),
-            'ContentType' = getPageContext().getServletContext().getMimeType( attachment )
+            'Name'        = attachment.name,
+            'Content'     = toBase64( fileReadBinary( attachment.srcfile ) ),
+            'ContentType' = getPageContext().getServletContext().getMimeType( attachment.srcfile )
           }
         );
       }
@@ -87,9 +87,9 @@ component output="false" accessors="true" {
           arrayAppend(
             aAttachments,
             {
-              'Name'        = attachment,
-              'Content'     = toBase64( fileReadBinary( attachment ) ),
-              'ContentType' = getPageContext().getServletContext().getMimeType( attachment )
+              'Name'        = attachment.name,
+              'Content'     = toBase64( fileReadBinary( attachment.srcfile ) ),
+              'ContentType' = getPageContext().getServletContext().getMimeType( attachment.srcfile )
             }
           );
         }

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ oPostmark.sendEmail(
   TextBody='This is the email email.',
   HtmlBody='<p>This is the email body</p>',
   attachments=[
-    '/attachments/test.txt',
-    '/attachments/something.png'
+    {name='Text File', srcfile='/attachments/test.txt'},
+    {name='Image', srcfile='/attachments/something.png'}
   ]
 );
 
@@ -73,8 +73,8 @@ oPostmark.sendBatchEmails(
       subject='First Batch Email',
       TextBody='This is an email.',
       attachments=[
-        '/attachments/test.txt',
-        '/attachments/something.png'
+        {name='Text File', srcfile='/attachments/test.txt'},
+        {name='Image', srcfile='/attachments/something.png'}
       ]
     },
     {


### PR DESCRIPTION
…g emails with an attachment that name is the full path on the server to the attachment file like `/root/serverHome/WEB-INF/lucee-web/temp/0CC77C0D-BD84-4395-8ACBAC6661EC6BD3.pdf` that is not very clear for the email receivers