### PR TITLE
Add support for metadata struct

### DIFF
--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -34,6 +34,7 @@ component output="false" accessors="true" {
   * @Headers List of custom headers to include.
   * @TrackOpens Activate open tracking for this email.
   * @TrackLinks Activate link tracking for links in the HTML or Text bodies of this email. Possible options: None HtmlAndText HtmlOnly TextOnly
+  * @Metadata Custom metadata key/value pairs.
   * @Attachments List of attachments as an array.
   */
   public function sendEmail(
@@ -50,6 +51,7 @@ component output="false" accessors="true" {
     array Headers,
     boolean TrackOpens,
     string TrackLinks,
+    struct Metadata,
     array Attachments
   ){
     var emailData = stripServerTokenAndClean( arguments );

--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -63,7 +63,7 @@ component output="false" accessors="true" {
           {
             'Name'        = attachment.name,
             'Content'     = toBase64( fileReadBinary( attachment.srcfile ) ),
-            'ContentType' = getPageContext().getServletContext().getMimeType( attachment.srcfile )
+            'ContentType' = fileGetMimeType( attachment.srcfile )
           }
         );
       }

--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -91,7 +91,7 @@ component output="false" accessors="true" {
             {
               'Name'        = attachment.name,
               'Content'     = toBase64( fileReadBinary( attachment.srcfile ) ),
-              'ContentType' = getPageContext().getServletContext().getMimeType( attachment.srcfile )
+              'ContentType' = fileGetMimeType( attachment.srcfile )
             }
           );
         }


### PR DESCRIPTION
Postmark has a Metadata struct for providing arbitrary info: https://postmarkapp.com/developer/api/email-api#send-a-single-email

Just added support for it.