### PR TITLE
Switch to using fileGetMimeType for attachments

### DIFF
--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -61,7 +61,7 @@ component output="false" accessors="true" {
           {
             'Name'        = attachment.name,
             'Content'     = toBase64( fileReadBinary( attachment.srcfile ) ),
-            'ContentType' = getPageContext().getServletContext().getMimeType( attachment.srcfile )
+            'ContentType' = fileGetMimeType( attachment.srcfile )
           }
         );
       }
@@ -89,7 +89,7 @@ component output="false" accessors="true" {
             {
               'Name'        = attachment.name,
               'Content'     = toBase64( fileReadBinary( attachment.srcfile ) ),
-              'ContentType' = getPageContext().getServletContext().getMimeType( attachment.srcfile )
+              'ContentType' = fileGetMimeType( attachment.srcfile )
             }
           );
         }


### PR DESCRIPTION
`getPageContext().getServletContext().getMimeType( attachment.srcfile )` was returning `null` for me, when trying to attach documents (Using Lucee 5.3.6+61 in CommandBox). 

Honestly, not sure of the cause of the issue, but switching this function resolved it.

That said, I believe that this breaks compatibility with CF9, and possibly Lucee 4.5, as CFDocs has the function `fileGetMimeType` added in CF10+: https://cfdocs.org/filegetmimetype

Given that ColdFusion 10 extended support [ended in 2019](https://helpx.adobe.com/support/programs/eol-matrix.html#CD), breaking compatibility with CF9 doesn't seem terrible, but obviously I'll leave that judgment up to you.