### PR TITLE
Serialize Body where necessary

### DIFF
--- a/Postmark.cfc
+++ b/Postmark.cfc
@@ -1020,7 +1020,7 @@ component output="false" accessors="true" {
       required string MatchName,
       string TrackOpens
   ){
-    var sBody = stripServerTokenAndClean( arguments );
+    var sBody = serializeJSON( stripServerTokenAndClean( arguments ) );
     return makeServerRequest( endpoint='triggers/tags', serverToken=arguments.serverToken, method='POST', body=sBody );
   }
 
@@ -1051,7 +1051,7 @@ component output="false" accessors="true" {
   ){
     var sParams = structCopy( arguments );
     structDelete( sParams, 'triggerId' );
-    var sBody = stripServerTokenAndClean( sParams );
+    var sBody = serializeJSON( stripServerTokenAndClean( sParams ) );
     return makeServerRequest( endpoint='triggers/tags/#arguments.triggerId#', serverToken=arguments.serverToken, method='PUT', body=sBody );
   }
 
@@ -1096,7 +1096,7 @@ component output="false" accessors="true" {
       required string serverToken,
       required string Rule
   ){
-    var sBody = stripServerTokenAndClean( arguments );
+    var sBody = serializeJSON( stripServerTokenAndClean( arguments ) );
     return makeServerRequest( endpoint='triggers/inboundrules', serverToken=arguments.serverToken, method='POST', body=sBody );
   }
 


### PR DESCRIPTION
In three functions, the body being sent to Postmark was not being converted to JSON. This updates those methods to use `serializeJSON`, as the rest of the methods in the CFC already do.